### PR TITLE
Correctly reflect omrepot execution failures in collector_success metrics

### DIFF
--- a/pkg/omreport/omreport_test.go
+++ b/pkg/omreport/omreport_test.go
@@ -13,7 +13,7 @@ type TestResultOMReport struct {
 
 func getOMReport(input *string) *OMReport {
 	return &OMReport{
-		Reader: func(f func([]string), _ string, args ...string) {
+		Reader: func(f func([]string), _ string, args ...string) error {
 			for _, line := range strings.Split(*input, "\n") {
 				sp := strings.Split(line, ";")
 				for i, s := range sp {
@@ -21,6 +21,7 @@ func getOMReport(input *string) *OMReport {
 				}
 				f(sp)
 			}
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
* `container: added flag to ignore omsa service start error` - Allow ignoring errors coming from the OMSA start service script (`--container=true` flag).
* `pkg/omreport: return error from OMReport.Reader func` - Meaning that the `dell_hw_scrape_collector_success` should now correctly reflect if they are successful `1` or not `0`.