### PR TITLE
Update logrus location to reflect new name

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "d682213848ed68c0a260ca37d6dd5ace8423f5ba"
   version = "v1.0.4"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@
 
 
 [[constraint]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   version = "1.0.4"
 
 [[constraint]]

--- a/cmd/dellhw_exporter/dellhw_exporter.go
+++ b/cmd/dellhw_exporter/dellhw_exporter.go
@@ -12,7 +12,7 @@ import (
 
 	"flag"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/galexrt/dellhw_exporter/collector"
 	"github.com/galexrt/dellhw_exporter/pkg/omreport"
 	"github.com/galexrt/pkg/flagutil"


### PR DESCRIPTION
The author of logrus changed the name of his account. Here we update
the name to avoid hitting the error:

case-insensitive import collision "github.com/sirupsen/logrus"

When building dellhw_exporter.

fixes #21