### PR TITLE
ci: update Travis CI golang version to 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - '1.10'
+  - '1.13'
 
 go_import_path: github.com/galexrt/dellhw_exporter
 


### PR DESCRIPTION
Signed-off-by: Alexander Trost <galexrt@googlemail.com>