### PR TITLE
Add support for firmware versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,18 @@ Should you run into issues when using the Docker image, please follow the [Troub
 
 ## Collectors
 
-Which collectors are enabled is controlled by the `--colectors.enabled` flag.
+Which collectors are enabled is controlled by the `--collectors-enabled` flag.
 
 ### Enabled by default
 
-All collectors are enabled by default. You can disable collectors by specifying the whole list of collectors through the `--collectors.enabled` flag.
+All collectors are enabled by default. You can disable collectors by specifying the whole list of collectors through the `--collectors-enabled` flag.
 
 | Name                 | Description                                                                      |
 | -------------------- | -------------------------------------------------------------------------------- |
 | chassis              | Overall status of chassis components.                                            |
 | chassis_batteries    | Overall status of chassis CMOS batteries.                                        |
 | fans                 | Overall status of system fans.                                                   |
+| firmwares            | Information about some firmware versions (Drac, BIOS)
 | memory               | System RAM DIMM status.                                                          |
 | nics                 | NICs connection status.                                                          |
 | processors           | Overall status of CPUs.                                                          |
@@ -70,7 +71,7 @@ $ dellhw_exporter --help
 unknown flag: --debug
 Usage of dellhw_exporter:
       --collectors-cmd-timeout int   Command execution timeout for omreport (default 15)
-      --collectors-enabled string    Comma separated list of active collectors (default "chassis,chassis_batteries,fans,memory,nics,processors,ps,ps_amps_sysboard_pwr,storage_battery,storage_controller,storage_enclosure,storage_pdisk,storage_vdisk,system,temps,volts")
+      --collectors-enabled string    Comma separated list of active collectors (default "chassis,chassis_batteries,fans,firmwares,memory,nics,processors,ps,ps_amps_sysboard_pwr,storage_battery,storage_controller,storage_enclosure,storage_pdisk,storage_vdisk,system,temps,volts")
       --collectors-omreport string   Path to the omReport executable (default "/opt/dell/srvadmin/bin/omreport")
       --collectors-print             If true, print available collectors and exit.
       --log-level string             Set log level (default "INFO")

--- a/cmd/dellhw_exporter/dellhw_exporter.go
+++ b/cmd/dellhw_exporter/dellhw_exporter.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	defaultCollectors = "chassis,chassis_batteries,fans,memory,nics,processors,ps,ps_amps_sysboard_pwr,storage_battery,storage_controller,storage_enclosure,storage_pdisk,storage_vdisk,system,temps,volts"
+	defaultCollectors = "chassis,chassis_batteries,fans,firmwares,memory,nics,processors,ps,ps_amps_sysboard_pwr,storage_battery,storage_controller,storage_enclosure,storage_pdisk,storage_vdisk,system,temps,volts"
 )
 
 var (

--- a/collector/firmwares.go
+++ b/collector/firmwares.go
@@ -1,0 +1,58 @@
+package collector
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type firmwaresCollector struct {
+	current *prometheus.Desc
+}
+
+func init() {
+	Factories["firmwares"] = NewFirmwaresCollector
+}
+
+// NewFirmwaresCollector returns a new firmwaresCollector
+func NewFirmwaresCollector() (Collector, error) {
+	return &firmwaresCollector{}, nil
+}
+
+// Update Prometheus metrics
+func (c *firmwaresCollector) Update(ch chan<- prometheus.Metric) error {
+	chassisBios, err := or.ChassisBios()
+	if err != nil {
+		return err
+	}
+	chassisFirmware, err := or.ChassisFirmware()
+	if err != nil {
+		return err
+	}
+	for _, value := range chassisBios {
+		float, err := strconv.ParseFloat(value.Value, 64)
+		if err != nil {
+			return err
+		}
+		c.current = prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", value.Name),
+			"Version info of firmwares/bios.",
+			nil, value.Labels)
+		ch <- prometheus.MustNewConstMetric(
+			c.current, prometheus.GaugeValue, float)
+	}
+	for _, value := range chassisFirmware {
+		float, err := strconv.ParseFloat(value.Value, 64)
+		if err != nil {
+			return err
+		}
+		c.current = prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", value.Name),
+			"Version info of firmwares/bios.",
+			nil, value.Labels)
+		ch <- prometheus.MustNewConstMetric(
+			c.current, prometheus.GaugeValue, float)
+	}
+
+	return nil
+}

--- a/pkg/omreport/omreport.go
+++ b/pkg/omreport/omreport.go
@@ -510,3 +510,51 @@ func (or *OMReport) ChassisBatteries() ([]Value, error) {
 	}, or.getOMReportExecutable(), "chassis", "batteries")
 	return values, err
 }
+
+// ChassisBios returns the bios version name
+func (or *OMReport) ChassisBios() ([]Value, error) {
+	value := Value{
+		Name:   "bios",
+		Value:  "0",
+		Labels: map[string]string{},
+	}
+
+	err := or.readReport(func(fields []string) {
+
+		if len(fields) != 2 {
+			return
+		}
+		id := strings.Replace(strings.ToLower(fields[0]), " ", "_", -1)
+		value.Labels[id] = strings.ToLower(fields[1])
+
+	}, or.getOMReportExecutable(), "chassis", "bios")
+
+	values := []Value{}
+	values = append(values, value)
+
+	return values, err
+}
+
+// ChassisFirmware returns the firmware revisions
+func (or *OMReport) ChassisFirmware() ([]Value, error) {
+	value := Value{
+		Name:   "firmware",
+		Value:  "0",
+		Labels: map[string]string{},
+	}
+
+	err := or.readReport(func(fields []string) {
+
+		if len(fields) != 2 {
+			return
+		}
+		id := strings.Replace(strings.ToLower(fields[0]), " ", "_", -1)
+		value.Labels[id] = strings.ToLower(fields[1])
+
+	}, or.getOMReportExecutable(), "chassis", "firmware")
+
+	values := []Value{}
+	values = append(values, value)
+
+	return values, err
+}

--- a/pkg/omreport/omreport_test.go
+++ b/pkg/omreport/omreport_test.go
@@ -821,10 +821,10 @@ var chassisBiosTests = []testResultOMReport{
 		`,
 		Values: []Value{
 			{
-				Name: "bios",
+				Name:  "bios",
 				Value: "0",
 				Labels: map[string]string{
-					"version": "2.10.5",
+					"version":      "2.10.5",
 					"manufacturer": "dell inc.",
 					"release_date": "07/25/2019",
 				},
@@ -853,10 +853,10 @@ var chassisFirmwareTests = []testResultOMReport{
 		`,
 		Values: []Value{
 			{
-				Name: "firmware",
+				Name:  "firmware",
 				Value: "0",
 				Labels: map[string]string{
-					"idrac8": "2.70.70.70 (build 45)",
+					"idrac8":               "2.70.70.70 (build 45)",
 					"lifecycle_controller": "2.70.70.70",
 				},
 			},

--- a/pkg/omreport/omreport_test.go
+++ b/pkg/omreport/omreport_test.go
@@ -293,17 +293,17 @@ ID;Status;Name;Slot ID;State;Firmware Version;Minimum Required Firmware Version;
 		Input: `List of Controllers in the system
 
 		Controller
-		
+
 		ID;Status;Name;Slot ID;State;Firmware Version;Minimum Required Firmware Version;Driver Version;Minimum Required Driver Version;Storport Driver Version;Minimum Required Storport Driver Version;Number of Connectors;Rebuild Rate;BGI Rate;Check Consistency Rate;Reconstruct Rate;Alarm State;Cluster Mode;SCSI Initiator ID;Cache Memory Size;Patrol Read Mode;Patrol Read State;Patrol Read Rate;Patrol Read Iterations;Abort Check Consistency on Error;Allow Revertible Hot Spare and Replace Member;Load Balance;Auto Replace Member on Predictive Failure;Redundant Path view;CacheCade Capable;Persistent Hot Spare;Encryption Capable;Encryption Key Present;Encryption Mode;Preserved Cache;Spin Down Unconfigured Drives;Spin Down Hot Spares;Spin Down Configured Drives;Automatic Disk Power Saving (Idle C);Start Time (HH:MM);Time Interval for Spin Up (in Hours);T10 Protection Information Capable;Non-RAID HDD Disk Cache Policy;Current Controller Mode
 		0;Ok;PERC H730P Mini;Embedded;Ready;25.5.5.0005;Not Applicable;06.810.09.00-rc1;Not Applicable;Not Applicable;Not Applicable;1;30%;30%;30%;30%;Not Applicable;Not Applicable;Not Applicable;2048 MB;Auto;Stopped;30%;159;Disabled;Enabled;Not Applicable;Disabled;Not Applicable;Not Applicable;Disabled;Yes;No;None;Not Applicable;Disabled;Disabled;Disabled;Disabled;Not Applicable;Not Applicable;No;Unchanged;RAID
-		
+
 		Controller
-		
+
 		ID;Status;Name;Slot ID;State;Firmware Version;Minimum Required Firmware Version;Driver Version;Minimum Required Driver Version;Storport Driver Version;Minimum Required Storport Driver Version;Number of Connectors;Rebuild Rate;BGI Rate;Check Consistency Rate;Reconstruct Rate;Alarm State;Cluster Mode;SCSI Initiator ID;Cache Memory Size;Patrol Read Mode;Patrol Read State;Patrol Read Rate;Patrol Read Iterations;Abort Check Consistency on Error;Allow Revertible Hot Spare and Replace Member;Load Balance;Auto Replace Member on Predictive Failure;Redundant Path view;CacheCade Capable;Persistent Hot Spare;Encryption Capable;Encryption Key Present;Encryption Mode;Preserved Cache;Spin Down Unconfigured Drives;Spin Down Hot Spares;Spin Down Configured Drives;Automatic Disk Power Saving (Idle C);Start Time (HH:MM);Time Interval for Spin Up (in Hours);T10 Protection Information Capable;Non-RAID HDD Disk Cache Policy
 		1;Ok;PERC H810 Adapter;PCI Slot 6;Ready;21.3.5-0002;Not Applicable;06.810.09.00-rc1;Not Applicable;Not Applicable;Not Applicable;2;30%;30%;30%;30%;Not Applicable;Not Applicable;Not Applicable;1024 MB;Auto;Stopped;30%;122;Disabled;Enabled;Auto;Disabled;Detected;Yes;Disabled;Yes;No;None;Not Applicable;Disabled;Disabled;Disabled;Disabled;Not Applicable;Not Applicable;No;Not Applicable
-		
+
 		Controller
-		
+
 		ID;Status;Name;Slot ID;State;Firmware Version;Minimum Required Firmware Version;Driver Version;Minimum Required Driver Version;Storport Driver Version;Minimum Required Storport Driver Version;Number of Connectors;Rebuild Rate;BGI Rate;Check Consistency Rate;Reconstruct Rate;Alarm State;Cluster Mode;SCSI Initiator ID;Cache Memory Size;Patrol Read Mode;Patrol Read State;Patrol Read Rate;Patrol Read Iterations;Abort Check Consistency on Error;Allow Revertible Hot Spare and Replace Member;Load Balance;Auto Replace Member on Predictive Failure;Redundant Path view;CacheCade Capable;Persistent Hot Spare;Encryption Capable;Encryption Key Present;Encryption Mode;Preserved Cache;Spin Down Unconfigured Drives;Spin Down Hot Spares;Spin Down Configured Drives;Automatic Disk Power Saving (Idle C);Start Time (HH:MM);Time Interval for Spin Up (in Hours);T10 Protection Information Capable;Non-RAID HDD Disk Cache Policy
 		2;Ok;PERC H810 Adapter;PCI Slot 4;Ready;21.3.5-0002;Not Applicable;06.810.09.00-rc1;Not Applicable;Not Applicable;Not Applicable;2;30%;30%;30%;30%;Not Applicable;Not Applicable;Not Applicable;1024 MB;Auto;Stopped;30%;96;Disabled;Enabled;Auto;Disabled;Detected;Yes;Disabled;Yes;No;None;Not Applicable;Disabled;Disabled;Disabled;Disabled;Not Applicable;Not Applicable;No;Not Applicable
 `,
@@ -769,8 +769,8 @@ Index;Status;Probe Name;Reading;Minimum Warning Threshold;Maximum Warning Thresh
 		Input: `Voltage Probes Information
 
 		Health : Ok
-		
-		
+
+
 		Index;Status;Probe Name;Reading;Minimum Warning Threshold;Maximum Warning Threshold;Minimum Failure Threshold;Maximum Failure Threshold
 		0;Ok;CPU1 VCORE PG;Good;[N/A];[N/A];[N/A];[N/A]
 		2;Ok;System Board 3.3V PG;Good;[N/A];[N/A];[N/A];[N/A]
@@ -807,6 +807,69 @@ func TestVolts(t *testing.T) {
 	for _, result := range voltsTests {
 		input = result.Input
 		values, _ := report.Volts()
+		assert.Equal(t, result.Values, values)
+	}
+}
+
+var chassisBiosTests = []testResultOMReport{
+	{
+		Input: `BIOS Information
+
+		Manufacturer;Dell Inc.
+		Version;2.10.5
+		Release Date;07/25/2019
+		`,
+		Values: []Value{
+			{
+				Name: "bios",
+				Value: "0",
+				Labels: map[string]string{
+					"version": "2.10.5",
+					"manufacturer": "dell inc.",
+					"release_date": "07/25/2019",
+				},
+			},
+		},
+	},
+}
+
+func TestChassisBios(t *testing.T) {
+	input := ""
+	report := getOMReport(&input)
+	for _, result := range chassisBiosTests {
+		input = result.Input
+		values, _ := report.ChassisBios()
+		assert.Equal(t, result.Values, values)
+	}
+}
+
+var chassisFirmwareTests = []testResultOMReport{
+	{
+		Input: `Firmware Information
+
+		Version Information
+		iDRAC8;2.70.70.70 (Build 45)
+		Lifecycle Controller;2.70.70.70
+		`,
+		Values: []Value{
+			{
+				Name: "firmware",
+				Value: "0",
+				Labels: map[string]string{
+					"idrac8": "2.70.70.70 (build 45)",
+					"lifecycle_controller": "2.70.70.70",
+				},
+			},
+		},
+	},
+}
+
+func TestChassisFirmware(t *testing.T) {
+	input := ""
+	report := getOMReport(&input)
+	for _, result := range chassisFirmwareTests {
+		input = result.Input
+		values, _ := report.ChassisFirmware()
 		assert.Equal(t, result.Values, values)
 	}
 }


### PR DESCRIPTION
This PR adds support for #43, adding a "firmwares" collector which provides 2 additional metrics for bios, idrac and lifecycle_controller version as labels. The metric values are always 0, only the labels of the metrics transport the info. 

I was unsure if those metrics maybe should be added to one of the existing collector (e.g. chassis), please comment on those, I can still move it around. 
At this place, we could add more metrics if more versions come available in omreport which are yet missing (nic, backplane, raid, ...)