### PR TITLE
kubernetes: added helm chart

### DIFF
--- a/charts/Makefile.common
+++ b/charts/Makefile.common
@@ -1,0 +1,10 @@
+GO   ?= go
+HELM ?= helm
+
+.PHONY: helm-docs
+helm-docs:
+	GO111MODULE=on $(GO) get github.com/norwoodj/helm-docs/cmd/helm-docs
+
+.PHONY: docs
+docs: helm-docs
+	helm-docs

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,9 @@
+# charts
+
+## dellhw_exporter
+
+The [dellhw_exporter/](dellhw_exporter/) chart.
+
+***
+
+The Helm chart documentation is auto generated using [https://github.com/norwoodj/helm-docs](https://github.com/norwoodj/helm-docs).

--- a/charts/dellhw_exporter/.helmignore
+++ b/charts/dellhw_exporter/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+Makefile

--- a/charts/dellhw_exporter/Chart.yaml
+++ b/charts/dellhw_exporter/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: dellhw_exporter
+description: A Helm chart for the dellhw_exporter
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.6.0

--- a/charts/dellhw_exporter/Makefile
+++ b/charts/dellhw_exporter/Makefile
@@ -1,0 +1,7 @@
+include ../Makefile.common
+
+.PHONY: template
+template:
+	$(HELM) template \
+		dellhw-exporter \
+		.

--- a/charts/dellhw_exporter/README.md
+++ b/charts/dellhw_exporter/README.md
@@ -1,0 +1,38 @@
+# dellhw_exporter
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+
+A Helm chart for the dellhw_exporter
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity for the DaemonSet |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | Override the `imagePullPolicy` |
+| image.repository | string | `"galexrt/dellhw-exporter"` | Image repository |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | ImagePullSecrets to add to the DaemonSet |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` | NodeSelector for the DaemonSet |
+| podAnnotations | object | `{}` | Annotations to add to the Pods created by the DaemonSet |
+| podLabels | object | `{}` | Additional labels to add to the Pods created by the DaemonSet |
+| podSecurityContext | object | `{}` | Kubernetes PodSecurityContext for the Pods |
+| prometheusRule.additionalLabels | object | `{}` | Additional Labels for the PrometheusRule object |
+| prometheusRule.enabled | bool | `false` | Specifies whether a prometheus-operator PrometheusRule should be created |
+| prometheusRule.rules | list | `[]` | Checkout the `/contrib/prometheus-alerts/prometheus-alerts.yml` file for example alerts |
+| psp.create | bool | `true` | Specifies whether a PodSecurityPolicy (PSP) should be created |
+| psp.spec | object | `{"allowedHostPaths":[],"privileged":true,"volumes":["secret"]}` | PodSecurityPolicy spec |
+| resources | object | `{}` |  |
+| securityContext | object | `{"privileged":true}` | SecurityContext for the container |
+| service.port | int | `9137` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` |  |
+| serviceMonitor.additionalLabels | object | `{}` | Additional Labels for the ServiceMonitor object |
+| serviceMonitor.enabled | bool | `false` | Specifies whether a prometheus-operator ServiceMonitor should be created |
+| serviceMonitor.namespaceSelector | string | `nil` |  |
+| serviceMonitor.scrapeInterval | string | `"30s"` |  |
+| tolerations | list | `[]` | Tolerations for the DaemonSet |

--- a/charts/dellhw_exporter/templates/NOTES.txt
+++ b/charts/dellhw_exporter/templates/NOTES.txt
@@ -1,0 +1,7 @@
+The dellhw_exporter has been configured with:
+
+* Image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+* (Non-default) ServiceAccount: {{ .Values.serviceAccount.create }}
+* PodSecurityPolicy: {{ .Values.psp.create }}
+* prometheus-operator ServiceMonitor: {{ .Values.serviceMonitor.enabled }}
+* prometheus-operator PrometheusRules: {{ .Values.prometheusRule.enabled }}

--- a/charts/dellhw_exporter/templates/_helpers.tpl
+++ b/charts/dellhw_exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dellhw_exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dellhw_exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dellhw_exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "dellhw_exporter.labels" -}}
+helm.sh/chart: {{ include "dellhw_exporter.chart" . }}
+{{ include "dellhw_exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "dellhw_exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dellhw_exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "dellhw_exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "dellhw_exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/dellhw_exporter/templates/daemonset.yaml
+++ b/charts/dellhw_exporter/templates/daemonset.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "dellhw_exporter.fullname" . }}
+  labels:
+    {{- include "dellhw_exporter.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "dellhw_exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "dellhw_exporter.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "dellhw_exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http-metrics
+              containerPort: 9137
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http-metrics
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/dellhw_exporter/templates/prometheusrules.yaml
+++ b/charts/dellhw_exporter/templates/prometheusrules.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.prometheusRule.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "dellhw_exporter.fullname" . }}
+{{- if .Values.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheusRule.namespace }}
+{{- end }}
+  labels:
+    {{- include "dellhw_exporter.labels" . | nindent 4 }}
+  {{- if .Values.prometheusRule.additionalLabels }}
+    {{- toYaml .Values.prometheusRule.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.prometheusRule.rules }}
+  groups:
+  - name: {{ template "dellhw_exporter.name" . }}
+    rules: {{- toYaml .Values.prometheusRule.rules | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/dellhw_exporter/templates/psp.yaml
+++ b/charts/dellhw_exporter/templates/psp.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.psp.create .Values.psp.spec -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "dellhw_exporter.fullname" . }}
+spec:
+  {{- with .Values.psp.spec }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dellhw_exporter.fullname" . }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ include "dellhw_exporter.fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dellhw_exporter.fullname" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "dellhw_exporter.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "dellhw_exporter.serviceAccountName" . }}
+  namespace: {{ .Release.Name }}
+{{- end }}

--- a/charts/dellhw_exporter/templates/service.yaml
+++ b/charts/dellhw_exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dellhw_exporter.fullname" . }}
+  labels:
+    {{- include "dellhw_exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http-metrics
+      protocol: TCP
+      name: http-metrics
+  selector:
+    {{- include "dellhw_exporter.selectorLabels" . | nindent 4 }}

--- a/charts/dellhw_exporter/templates/serviceaccount.yaml
+++ b/charts/dellhw_exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dellhw_exporter.serviceAccountName" . }}
+  labels:
+    {{- include "dellhw_exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/dellhw_exporter/templates/servicemonitor.yaml
+++ b/charts/dellhw_exporter/templates/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "dellhw_exporter.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+  labels:
+    {{- include "dellhw_exporter.labels" . | nindent 4 }}
+  {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - port: http-metrics
+      interval: {{ .Values.serviceMonitor.scrapeInterval }}
+    {{- if .Values.serviceMonitor.honorLabels }}
+      honorLabels: true
+    {{- end }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 8 }}
+    {{- end }}
+{{- if .Values.serviceMonitor.namespaceSelector }}
+  namespaceSelector: {{ toYaml .Values.serviceMonitor.namespaceSelector | nindent 4 }}
+{{ else }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+  {{- range .Values.serviceMonitor.targetLabels }}
+    - {{ . }}
+  {{- end }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "dellhw_exporter.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/dellhw_exporter/values.yaml
+++ b/charts/dellhw_exporter/values.yaml
@@ -1,0 +1,105 @@
+# Default values for dellhw_exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- Image repository
+  repository: galexrt/dellhw-exporter
+  # -- Override the `imagePullPolicy`
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# -- ImagePullSecrets to add to the DaemonSet
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- If not set and create is true, a name is generated using the fullname template
+  # -- The name of the service account to use.
+  name: ""
+
+# -- Annotations to add to the Pods created by the DaemonSet
+podAnnotations: {}
+# -- Additional labels to add to the Pods created by the DaemonSet
+podLabels: {}
+
+# -- Kubernetes PodSecurityContext for the Pods
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# -- SecurityContext for the container
+securityContext:
+  privileged: true
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+psp:
+  # -- Specifies whether a PodSecurityPolicy (PSP) should be created
+  create: true
+  # -- PodSecurityPolicy spec
+  spec:
+    privileged: true
+    allowedHostPaths: []
+    volumes:
+      - secret
+
+service:
+  type: ClusterIP
+  port: 9137
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  # -- NodeSelector for the DaemonSet
+nodeSelector: {}
+
+# -- Tolerations for the DaemonSet
+tolerations: []
+
+# -- Affinity for the DaemonSet
+affinity: {}
+
+serviceMonitor:
+  # -- Specifies whether a prometheus-operator ServiceMonitor should be created
+  enabled: false
+  # -- Additional Labels for the ServiceMonitor object
+  additionalLabels: {}
+  #namespace: "monitoring"
+  namespaceSelector:
+  # Default: scrape .Release.Namespace only
+  # To scrape all, use the following:
+  #  matchNames:
+  #    - monitoring
+  #   any: true
+  scrapeInterval: 30s
+  # honorLabels: true
+
+prometheusRule:
+  # -- Specifies whether a prometheus-operator PrometheusRule should be created
+  enabled: false
+  # -- Additional Labels for the PrometheusRule object
+  additionalLabels: {}
+  # Default: .Release.Namespace
+  # namespace: ""
+  # prometheusRule.rules -- Checkout the `/contrib/prometheus-alerts/prometheus-alerts.yml` file for example alerts
+  rules: []


### PR DESCRIPTION
This helm chart has the basic options to deploy a DaemonSet of the
dellhw_exporter. There are more (comfort) features to come in the
future, but as it is right now it is a good start.

Resolves #50

Signed-off-by: Alexander Trost <galexrt@googlemail.com>