### PR TITLE
ci: enable windows/amd64 crossbuilds

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -26,7 +26,7 @@ crossbuild:
         - linux/386
         #- darwin/amd64
         #- darwin/386
-        #- windows/amd64
+        - windows/amd64
         #- windows/386
         #- freebsd/amd64
         #- freebsd/386


### PR DESCRIPTION
This will cause windows/amd64 binaries to be built during the next
release / tag made.

Signed-off-by: Alexander Trost <galexrt@googlemail.com>

***

A local `promu crossbuild` in itself succeeded.