### PR TITLE
Addition of Remaining Rated Write Endurance metric for Pdisk

### DIFF
--- a/pkg/omreport/omreport.go
+++ b/pkg/omreport/omreport.go
@@ -275,6 +275,15 @@ func (or *OMReport) StoragePdisk(cid string) ([]Value, error) {
 					controllerNameLabel: controllerName,
 				},
 			})
+			values = append(values, Value{
+				Name:  "storage_pdisk_remaining_rated_write_endurance",
+				Value: getNumberFromString(fields[8]),
+				Labels: map[string]string{
+					controllerLabel:     cid,
+					"disk":              id,
+					controllerNameLabel: controllerName,
+				},
+			})
 		}
 	}, or.getOMReportExecutable(), "storage", "pdisk", "controller="+cid)
 	return values, err

--- a/pkg/omreport/omreport_test.go
+++ b/pkg/omreport/omreport_test.go
@@ -426,6 +426,15 @@ ID;Status;Name;State;Power Status;Bus Protocol;Media;Part of Cache Pool;Remainin
 				},
 			},
 			{
+				Name:  "storage_pdisk_remaining_rated_write_endurance",
+				Value: "100",
+				Labels: map[string]string{
+					"controller":        "0",
+					"disk":              "0_1_0",
+					controllerNameLabel: "PERC H730 Mini (Slot Embedded)",
+				},
+			},
+			{
 				Name:  "storage_pdisk_status",
 				Value: "0",
 				Labels: map[string]string{
@@ -437,6 +446,15 @@ ID;Status;Name;State;Power Status;Bus Protocol;Media;Part of Cache Pool;Remainin
 			{
 				Name:  "storage_pdisk_failure_predicted",
 				Value: "0",
+				Labels: map[string]string{
+					"controller":        "0",
+					"disk":              "0_1_1",
+					controllerNameLabel: "PERC H730 Mini (Slot Embedded)",
+				},
+			},
+			{
+				Name:  "storage_pdisk_remaining_rated_write_endurance",
+				Value: "100",
 				Labels: map[string]string{
 					"controller":        "0",
 					"disk":              "0_1_1",
@@ -455,6 +473,15 @@ ID;Status;Name;State;Power Status;Bus Protocol;Media;Part of Cache Pool;Remainin
 			{
 				Name:  "storage_pdisk_failure_predicted",
 				Value: "1",
+				Labels: map[string]string{
+					"controller":        "0",
+					"disk":              "0_2_0",
+					controllerNameLabel: "PERC H730 Mini (Slot Embedded)",
+				},
+			},
+			{
+				Name:  "storage_pdisk_remaining_rated_write_endurance",
+				Value: "100",
 				Labels: map[string]string{
 					"controller":        "0",
 					"disk":              "0_2_0",


### PR DESCRIPTION
Would like to add remaining disk endurance metric in omreport as it will help in monitoring and alerting when disk endurance hits a threshold. This is helpful for monitoring all SSDs across the servers.


